### PR TITLE
Fix offsets after collapsed reference links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## MMark 0.0.6.2
+
+* Fixed setting offset after parsing of collapsed reference links.
+  Previously offset in parser state was restored incorrectly and errors that
+  would happen after such links would be reported two characters before
+  their real position.
+
 ## MMark 0.0.6.1
 
 * Dropped `data-default-class` dependency.

--- a/Text/MMark/Parser.hs
+++ b/Text/MMark/Parser.hs
@@ -780,11 +780,11 @@ pLocation innerOffset inner = do
       pRefLabel >>= uncurry lookupRef
     collapsed o inlines = do
       -- NOTE We need to do these manipulations so the failure caused by
-      -- 'string' "" does not overwrite our custom failures.
+      -- @'string' "[]"@ does not overwrite our custom failures.
       o' <- getOffset
       setOffset o
       (void . hidden . string) "[]"
-      setOffset o'
+      setOffset (o' + 2)
       lookupRef o (mkLabel inlines)
     shortcut o inlines =
       lookupRef o (mkLabel inlines)

--- a/tests/Text/MMarkSpec.hs
+++ b/tests/Text/MMarkSpec.hs
@@ -1790,6 +1790,10 @@ spec = parallel $ do
       it "a composite, complex example" $
         "***Something ~~~is not~~ going~ ^so well^** today*." ==->
           "<p><em><strong>Something <sub><del>is not</del> going</sub> <sup>so well</sup></strong> today</em>.</p>\n"
+    context "collapsed reference links (special cases)" $
+      it "offsets after such links are still correct" $
+        "[foo][] *foo\n\n[foo]: https://example.org" ~-> err 12
+           (ueib <> etok '*' <> eic)
     context "title parse errors" $
       it "parse error is OK in reference definitions" $
         let s = "[something]: something something"


### PR DESCRIPTION
Fixed setting offset after parsing of collapsed reference links. Previously offset in parser state was restored incorrectly and errors that would happen after such links would be reported two characters before their real
position.