### PR TITLE
fix: Bump nodejs to 8.x in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
             - hvr-ghc
             - sourceline: 'ppa:hvr/ghcjs'
             - ubuntu-toolchain-r-test
-            - sourceline: 'deb https://deb.nodesource.com/node_6.x trusty main'
+            - sourceline: 'deb https://deb.nodesource.com/node_8.x xenial main'
               key_url: 'https://deb.nodesource.com/gpgkey/nodesource.gpg.key'
           packages: [cabal-install-2.4, ghcjs-8.4, alex, happy]
 


### PR DESCRIPTION
Ignore this PR for now. I couldn't get travis to work against my repo so I'm just raising a PR to test on your CI. :slightly_smiling_face: 