### PR TITLE
WIP feat: add monadic support

### DIFF
--- a/Text/MMark.hs
+++ b/Text/MMark.hs
@@ -116,11 +116,14 @@
 module Text.MMark
   ( -- * Parsing
     MMark,
+    MMarkM,
     MMarkErr (..),
     parse,
+    parseM,
 
     -- * Extensions
     Extension,
+    ExtensionM,
     useExtension,
     useExtensions,
 
@@ -136,7 +139,7 @@ where
 
 import qualified Control.Foldl as L
 import Data.Aeson
-import Text.MMark.Parser (MMarkErr (..), parse)
+import Text.MMark.Parser (MMarkErr (..), parse, parseM)
 import Text.MMark.Render (render)
 import Text.MMark.Type
 
@@ -151,7 +154,7 @@ import Data.Semigroup ((<>))
 -- apply 'Extension's /does matter/. Extensions you apply first take effect
 -- first. The extension system is designed in such a way that in many cases
 -- the order doesn't matter, but sometimes the difference is important.
-useExtension :: Extension -> MMark -> MMark
+useExtension :: Monad m => ExtensionM m -> MMarkM m -> MMarkM m
 useExtension ext mmark =
   mmark {mmarkExtension = ext <> mmarkExtension mmark}
 
@@ -164,7 +167,7 @@ useExtension ext mmark =
 -- As mentioned in the docs for 'useExtension', the order in which you apply
 -- extensions matters. Extensions closer to beginning of the list are
 -- applied later, i.e. the last extension in the list is applied first.
-useExtensions :: [Extension] -> MMark -> MMark
+useExtensions :: Monad m => [ExtensionM m] -> MMarkM m -> MMarkM m
 useExtensions exts = useExtension (mconcat exts)
 
 ----------------------------------------------------------------------------
@@ -182,7 +185,7 @@ runScanner ::
   L.Fold Bni a ->
   -- | Result of scanning
   a
-runScanner MMark {..} f = L.fold f mmarkBlocks
+runScanner MMarkM {..} f = L.fold f mmarkBlocks
 
 -- | Like 'runScanner', but allows to run scanners with monadic context.
 --
@@ -198,8 +201,8 @@ runScannerM ::
   L.FoldM m Bni a ->
   -- | Result of scanning
   m a
-runScannerM MMark {..} f = L.foldM f mmarkBlocks
+runScannerM MMarkM {..} f = L.foldM f mmarkBlocks
 
 -- | Extract contents of an optional YAML block that may have been parsed.
-projectYaml :: MMark -> Maybe Value
+projectYaml :: MMarkM m -> Maybe Value
 projectYaml = mmarkYaml

--- a/Text/MMark/Parser.hs
+++ b/Text/MMark/Parser.hs
@@ -21,6 +21,7 @@
 module Text.MMark.Parser
   ( MMarkErr (..),
     parse,
+    parseM,
   )
 where
 
@@ -105,7 +106,17 @@ parse ::
   Text ->
   -- | Parse errors or parsed document
   Either (ParseErrorBundle Text MMarkErr) MMark
-parse file input =
+parse = parseM
+
+parseM ::
+  Monad m =>
+  -- | File name (only to be used in error messages), may be empty
+  FilePath ->
+  -- | Input to parse
+  Text ->
+  -- | Parse errors or parsed document
+  Either (ParseErrorBundle Text MMarkErr) (MMarkM m)
+parseM file input =
   case runBParser pMMark file input of
     Left bundle -> Left bundle
     Right ((myaml, rawBlocks), defs) ->
@@ -118,7 +129,7 @@ parse file input =
        in case NE.nonEmpty . DList.toList $ foldMap (foldMap e2p) parsed of
             Nothing ->
               Right
-                MMark
+                MMarkM
                   { mmarkYaml = myaml,
                     mmarkBlocks = fmap fromRight <$> parsed,
                     mmarkExtension = mempty

--- a/mmark.cabal
+++ b/mmark.cabal
@@ -104,6 +104,7 @@ test-suite tests
         megaparsec >=8.0 && <10.0,
         mmark -any,
         modern-uri >=0.3 && <0.4,
+        mtl >=2.0 && <3.0,
         text >=0.2 && <1.3
 
     if flag(dev)

--- a/tests/Text/MMark/TestUtils.hs
+++ b/tests/Text/MMark/TestUtils.hs
@@ -4,7 +4,9 @@
 module Text.MMark.TestUtils
   ( -- * Document creation and rendering
     mkDoc,
+    mkDocM,
     toText,
+    toTextM,
 
     -- * Parser expectations
     (~~->),
@@ -21,7 +23,7 @@ import Data.Text (Text)
 import qualified Data.Text.Lazy as TL
 import qualified Lucid as L
 import Test.Hspec
-import Text.MMark (MMark, MMarkErr)
+import Text.MMark (MMark, MMarkErr, MMarkM)
 import qualified Text.MMark as MMark
 import Text.Megaparsec
 
@@ -35,8 +37,11 @@ import Data.Semigroup ((<>))
 -- | Create an 'MMark' document from given input reporting an expectation
 -- failure if it cannot be parsed.
 mkDoc :: Text -> IO MMark
-mkDoc input =
-  case MMark.parse "" input of
+mkDoc = mkDocM
+
+mkDocM :: Monad m => Text -> IO (MMarkM m)
+mkDocM input =
+  case MMark.parseM "" input of
     Left bundle -> do
       expectationFailure $
         "while parsing a document, parse error(s) occurred:\n"
@@ -47,6 +52,10 @@ mkDoc input =
 -- | Render an 'MMark' document to 'Text'.
 toText :: MMark -> Text
 toText = TL.toStrict . L.renderText . MMark.render
+
+-- | Render an 'MMark' document to 'm Text'.
+toTextM :: Monad m => MMarkM m -> m Text
+toTextM = fmap TL.toStrict . L.renderTextT . MMark.render
 
 ----------------------------------------------------------------------------
 -- Parser expectations


### PR DESCRIPTION
This PR would add support for monadic transformation and rendering.

The main motivation is to give the possibility for transforming and rendering in a certain monad (as requested in #46 ). For example, one might want to call an external service to render a specific content.

The scan alternative (i.e. doing a scanning beforehand, then send the results to the rendering extension) is not enough as scanning only consider the original content, not the one that might get constructed from the content and the application of other extensions. Adding the possibility to scan over the transformed content would solve that problem, but leave something to be desired (intermediate information generated, having some internals hidden but the transformed content publicly visible...).

This PR would solve the problem by introducing monad support for MMark, support that is already present in Lucid.

While the code should not introduce major breaking changes, there's still some open question regarding performance and ease of use (`MMarkM m` might seem a little weird, just as the `parse` function that just doesn't care about the monad).

Is this PR worth investigating?