### PR TITLE
Allow text-2.0

### DIFF
--- a/mmark.cabal
+++ b/mmark.cabal
@@ -62,7 +62,7 @@ library
         modern-uri >=0.3.4 && <0.4,
         mtl >=2.0 && <3.0,
         parser-combinators >=0.4 && <2.0,
-        text >=0.2 && <1.3,
+        text >=0.2 && <2.1,
         text-metrics >=0.3 && <0.4,
         unordered-containers >=0.2.5 && <0.3
 
@@ -104,7 +104,7 @@ test-suite tests
         megaparsec >=8.0 && <10.0,
         mmark,
         modern-uri >=0.3 && <0.4,
-        text >=0.2 && <1.3
+        text >=0.2 && <2.1
 
     if flag(dev)
         ghc-options: -O0 -Wall -Werror
@@ -124,7 +124,7 @@ benchmark bench-speed
         base >=4.13 && <5.0,
         criterion >=0.6.2.1 && <1.6,
         mmark,
-        text >=0.2 && <1.3
+        text >=0.2 && <2.1
 
     if flag(dev)
         ghc-options: -O2 -Wall -Werror
@@ -143,7 +143,7 @@ benchmark bench-memory
     build-depends:
         base >=4.13 && <5.0,
         mmark,
-        text >=0.2 && <1.3,
+        text >=0.2 && <2.1,
         weigh >=0.0.4
 
     if flag(dev)


### PR DESCRIPTION
https://hackage.haskell.org/package/text-2.0/changelog

Tested with

    cabal test all --constraint 'text >= 2' --allow-newer=modern-uri:text,html-entity-map:text