### PR TITLE
Test with GHC 9.14.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,8 +18,8 @@ jobs:
     needs: ormolu
     strategy:
       matrix:
-        cabal: ["3.12"]
-        ghc: ["9.8.4", "9.10.3", "9.12.1"]
+        cabal: ["3.16"]
+        ghc: ["9.10.3", "9.12.4", "9.14.1"]
     steps:
       - uses: actions/checkout@v6
       - uses: haskell-actions/setup@v2.10.3

--- a/mmark.cabal
+++ b/mmark.cabal
@@ -5,7 +5,7 @@ license:         BSD-3-Clause
 license-file:    LICENSE.md
 maintainer:      Mark Karpov <markkarpov92@gmail.com>
 author:          Mark Karpov <markkarpov92@gmail.com>
-tested-with:     ghc ==9.8.4 ghc ==9.10.3 ghc ==9.12.1
+tested-with:     ghc ==9.10.3 ghc ==9.12.4 ghc ==9.14.1
 homepage:        https://github.com/mmark-md/mmark
 bug-reports:     https://github.com/mmark-md/mmark/issues
 synopsis:        Strict markdown processor for writers


### PR DESCRIPTION
Looks like this is pending a release of `lucid` that is compatible with GHC 9.14.